### PR TITLE
Win32: remove <sys/uio.h>

### DIFF
--- a/tests/client.c
+++ b/tests/client.c
@@ -12,10 +12,10 @@
 #include <arpa/inet.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <sys/uio.h>
 #endif
 
 #include <sys/types.h>
-#include <sys/uio.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>


### PR DESCRIPTION
As a first step to make the `tests/*.c` programs compile, remove the `<sys/uio.h>` header for `_WIN32`.
(it's a Posix header not present for MSVC/MinGW).